### PR TITLE
fix: rsync uploads fail on openrsync ("empty remote host")

### DIFF
--- a/src/Model/Alias.php
+++ b/src/Model/Alias.php
@@ -348,6 +348,51 @@ final class Alias implements Stringable {
 	}
 
 	/**
+	 * Build the SSH transport for rsync's `--rsh`/`-e` option.
+	 *
+	 * This intentionally does NOT reuse {@see self::generate_ssh_command()}.
+	 * That method returns a fully shell-escaped command meant to be executed
+	 * as-is (`ssh 'user@host' 'cmd'`); handing it to rsync's `--rsh` escapes it
+	 * a second time. GNU rsync peels the extra quotes back off, but stricter
+	 * `-e` parsers -- notably openrsync, the `/usr/bin/rsync` on macOS 15+ and
+	 * the BSDs -- do not, so the literal quotes reach `ssh` and the host fails
+	 * to resolve.
+	 *
+	 * Instead we emit a transport-only string that the caller escapes exactly
+	 * once. The host is not part of the transport; it travels in the location
+	 * built by {@see self::get_rsync_location()}. `-T` is forced so rsync's
+	 * binary stream is never attached to a TTY (e.g. an ssh_config `RequestTTY`).
+	 *
+	 * @return string
+	 */
+	public function get_rsync_rsh(): string {
+		$rsh = [ 'ssh', '-T' ];
+		if ( null !== $this->port ) {
+			$rsh[] = '-p ' . $this->port;
+		}
+		if ( null !== $this->key ) {
+			$rsh[] = '-i ' . escapeshellarg( $this->key );
+		}
+
+		return implode( ' ', $rsh );
+	}
+
+	/**
+	 * Build a remote rsync location (`[user@]host:path`) for this alias.
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	public function get_rsync_location( string $path ): string {
+		$host = (string) $this->host;
+		if ( null !== $this->user ) {
+			$host = "{$this->user}@{$host}";
+		}
+
+		return "{$host}:{$path}";
+	}
+
+	/**
 	 * Run a WP-CLI command
 	 *
 	 * @param string $command

--- a/src/MoveCommand.php
+++ b/src/MoveCommand.php
@@ -393,16 +393,17 @@ class MoveCommand {
 
 		$this->log_section( sprintf( '%s %s', $to->is_local() ? '⬇️ Pulling uploads from' : '⬆️ Pushing uploads to', $remote ) );
 
-		$rsync_args        = self::DEFAULT_RSYNC_ARGS;
-		$rsync_args['rsh'] = $remote->generate_ssh_command( '' );
+		$rsync_args = Utils\assoc_args_to_str( self::DEFAULT_RSYNC_ARGS );
 
-		// Build rsync command
-		$rsync_args = Utils\assoc_args_to_str( $rsync_args );
+		$source = $from->is_local() ? "{$from_path}/" : $from->get_rsync_location( "{$from_path}/" );
+		$target = $to->is_local() ? "{$to_path}/" : $to->get_rsync_location( "{$to_path}/" );
 
-		$source = $from->is_local() ? "{$from_path}/" : ":{$from_path}/";
-		$target = $to->is_local() ? "{$to_path}/" : ":{$to_path}/";
-
-		$command = Utils\esc_cmd( "{$rsync_args} %s %s", $source, $target );
+		// Build the transport ourselves instead of via generate_ssh_command():
+		// that returns an already shell-escaped command, so routing it through
+		// --rsh escapes it twice. GNU rsync tolerates the extra quotes, but
+		// openrsync (macOS 15+/BSD) does not. esc_cmd escapes the transport
+		// exactly once; the host travels in the `[user@]host:path` location.
+		$command = Utils\esc_cmd( "{$rsync_args} --rsh=%s %s %s", $remote->get_rsync_rsh(), $source, $target );
 
 		$local->run_command( 'rsync', $command, $dry_run );
 	}


### PR DESCRIPTION
## Problem

Syncing uploads fails on some machines with:

```
rsync: empty remote host
```

`sync_uploads()` pointed rsync at a target like `':/…/uploads/'` — an **empty host** before the colon — with the real host baked into `--rsh` (`ssh … 'user@host'`). GNU rsync tolerates the empty host (it falls back to the host in the rsh command), so it works on Linux and Homebrew rsync. But **openrsync** — the `/usr/bin/rsync` Apple ships on macOS 15+, and the BSDs — validates the target and rejects an empty remote host outright, before it even runs the transport.

Two related fragilities in the same construction:

- the `--rsh` value was **double shell-escaped** — `generate_ssh_command()` returns an already-escaped command, then `assoc_args_to_str()` escaped it again. GNU rsync's `-e` parser peels the extra quotes back off; stricter parsers may not.
- it carried `-t` (request a TTY), inherited from `generate_ssh_command()`'s interactive-`wp` purpose, which is wrong for rsync's binary stream.

## Fix

Build the rsync invocation directly instead of reusing `generate_ssh_command()`:

- `Alias::get_rsync_location()` — a standard `[user@]host:path` location, so the host is **always explicit** (no empty-host target).
- `Alias::get_rsync_rsh()` — a transport-only `ssh -T [-p port] [-i key]`, escaped exactly once; `-T` keeps rsync's stream off a TTY.

`generate_ssh_command()` is unchanged and still used by `run_command()` / `export_db()`.

## Before / after

```diff
- rsync … --rsh='ssh -t -q '\''user@host'\''' ':/…/uploads/' '/…/uploads/'
+ rsync … --rsh='ssh -T' 'user@host:/…/uploads/' '/…/uploads/'
```

## Testing

- Reproduced end-to-end against a real sshd in Docker, including a hostile `RequestTTY force` ssh_config; the standard `user@host:path` form transfers and verifies by checksum.
- Matches a real openrsync failure (`rsync: empty remote host`) reported by a macOS user.

## Follow-up

- Unit tests for `get_rsync_rsh()` / `get_rsync_location()`, plus a forced-TTY fix for `export_db()`, are in a follow-up branch.
- `proxyjump` is not carried into the transport (it was already unused for rsync — `Alias::create()` never captured it), so no regression; trivial to add if needed.
